### PR TITLE
mac80211: Fix potential endless loop

### DIFF
--- a/package/kernel/mac80211/patches/subsys/370-mac80211-fix-misplaced-while-instead-of-if.patch
+++ b/package/kernel/mac80211/patches/subsys/370-mac80211-fix-misplaced-while-instead-of-if.patch
@@ -1,0 +1,31 @@
+From 5981fe5b0529ba25d95f37d7faa434183ad618c5 Mon Sep 17 00:00:00 2001
+From: Johannes Berg <johannes.berg@intel.com>
+Date: Mon, 3 Aug 2020 11:02:10 +0200
+Subject: [PATCH] mac80211: fix misplaced while instead of if
+
+This never was intended to be a 'while' loop, it should've
+just been an 'if' instead of 'while'. Fix this.
+
+I noticed this while applying another patch from Ben that
+intended to fix a busy loop at this spot.
+
+Cc: stable@vger.kernel.org
+Fixes: b16798f5b907 ("mac80211: mark station unauthorized before key removal")
+Reported-by: Ben Greear <greearb@candelatech.com>
+Link: https://lore.kernel.org/r/20200803110209.253009ae41ff.I3522aad099392b31d5cf2dcca34cbac7e5832dde@changeid
+Signed-off-by: Johannes Berg <johannes.berg@intel.com>
+---
+ net/mac80211/sta_info.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/net/mac80211/sta_info.c
++++ b/net/mac80211/sta_info.c
+@@ -980,7 +980,7 @@ static void __sta_info_destroy_part2(str
+ 	might_sleep();
+ 	lockdep_assert_held(&local->sta_mtx);
+ 
+-	while (sta->sta_state == IEEE80211_STA_AUTHORIZED) {
++	if (sta->sta_state == IEEE80211_STA_AUTHORIZED) {
+ 		ret = sta_info_move_state(sta, IEEE80211_STA_ASSOC);
+ 		WARN_ON_ONCE(ret);
+ 	}


### PR DESCRIPTION
Backport a fix from kernel 5.8.3.

Signed-off-by: Hauke Mehrtens <hauke@hauke-m.de>
(cherry picked from commit ca5ee6eba34593ec9f8b5b195c94cf6c3f6ff914)
